### PR TITLE
fix(bug): 🐛Ensure valid budget input before proceeding and do not sub…

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
     <div class="container mx-auto max-w-7xl bg-white rounded-3xl p-10 md:flex gap-10 shadow-green-950 shadow-2xl">
         <div id="right" class="w-full md:w-1/2">
             <h2 class="text-center mb-8 text-2xl text-gray-400">Add your expenses here</h2>
-            <!-- <div class="bg-red-200 text-red-700 px-5 py-3 mb-5 rounded-lg border border-red-300 text-center">All field are mandatory</div> -->
             <form id="form-expenses" class="flex flex-col gap-3" >
                 <label for="expense">Expense: </label>
                 <input id="expense" class="border p-2 rounded-md" type="text" name="expense"  placeholder="Expense name">
@@ -31,12 +30,6 @@
             <h2 class="text-center mb-10 text-2xl text-gray-400">List</h2>
             <div id="expenses-block">
                 <ul id="expenses-list" class="mb-5" >
-                    <!-- <div class="p-4 border flex md:flex-row flex-col justify-between">
-                        <p class="mt-2 text-center">Comida: </p>
-                        <p class="bg-green-200 border border-green-300 px-2 py-1 font-bold text-center mb-1 text-green-900  rounded-md">$400</p>
-                        <button class="bg-red-600  text-white px-2 py-1 rounded-md mb-1">Borrar x</button>
-                    </div> -->
-                    
                 </ul>
             </div>
             <div id="budget-block" class="justify-center align-middle md:pt-8" >

--- a/js/index.js
+++ b/js/index.js
@@ -146,14 +146,18 @@ let budget;
 // Functions
 function askBudget() {
     //Ask the user for the budget
-    const budgetUser = prompt("what is your budget?")
+    let budgetUser = prompt("what is your budget? enter the amount ")
 
-    if (budgetUser === '' || budgetUser <= 0 || isNaN(budgetUser) || budgetUser === 'null') {
-        window.location.reload()
+    while(budgetUser === '' || budgetUser <= 0 || isNaN(budgetUser) || budgetUser === null) {
+        budgetUser = prompt("Invalid amount, try again ");
+    }
+    if(budgetUser === '' || budgetUser <= 0 || isNaN(budgetUser) || budgetUser === null) {
+        window.location.reload();
     }
     budget = new Budget(budgetUser);
     iu.fillBudgetField(budget)
 }
+
 
 function validationInput(e) {
 


### PR DESCRIPTION
…mit a response if it is invalid

This change ensures that the user provides a valid budget amount before proceeding, and if they fail to do so, the page is reloaded to restart the process.